### PR TITLE
Servindo o link de download direto do Google Drive em vídeos

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -833,7 +833,7 @@ function file_video(path) {
   <input type="text" class="form-control" id="dlurl" value="${url}">
 </div>
 <div class="btn-group text-center">
-    <a href="${url}" type="button" class="btn btn-primary">Download</a>
+    <a href="https://drive.google.com/uc?export=download&id=${obj.id}" type="button" class="btn btn-primary">Download</a>
 </div>
 <button onclick="copyFunction()" onmouseout="outFunc()" class="btn btn-success"> <span class="tooltiptext" id="myTooltip">Copiar</span> </button>
 <br>


### PR DESCRIPTION
Dessa forma, não haverá problemas com limitações por quebra dos termos de serviço da Cloudflare.